### PR TITLE
Add 'iPad mini 2' to Tested devices list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
   - iPad Air Gen 1 (As of 10/27/2022)
 - iOS 12.5.7
   - iPad Mini 3 (As of 01/13/2025 - Thanks to [adamk324](<https://github.com/adamk324> "adamk324"))
-  
+  - iPad Mini 2 (As of 02/26/2025 - Thanks to [ManiProjs](<https://github.com/ManiProjs> "ManiProjs"))
+
 ### Jailbreak the iDevice ###
 - Jailbreak with Checkra1n 0.10.2 
   - https://checkra.in/releases/0.10.2-beta#all-downloads


### PR DESCRIPTION
Hi. Yesterday (which means 2/26/2025), I tested this tool on my old iPad mini 2 (Wi-Fi). And it worked flawlessly. So, I've added iPad mini 2 to "Confirmed Working Devices"

_**I used a Windows 11 VM on my Mac. If it works on VM, it works on host OS, too**_